### PR TITLE
Force push release docs branch

### DIFF
--- a/.github/workflows/create_pull_request.yml
+++ b/.github/workflows/create_pull_request.yml
@@ -11,13 +11,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    
 
     - name: Clone release branch to create pull request
       run: |
         git checkout ${{ github.event.client_payload.ReleaseBranchName }}
         git branch ${{ github.event.client_payload.ReleaseBranchName }}-docs
-        git push origin ${{ github.event.client_payload.ReleaseBranchName }}-docs
+        git push origin ${{ github.event.client_payload.ReleaseBranchName }}-docs --force
 
     - name: Create pull request for ${{ github.event.client_payload.ReleaseBranchName }}
       id: create-pr


### PR DESCRIPTION
# Description

Fixes failure creating release PR if workflow previous attempt to run Actions workflow failed to resolve run id.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
